### PR TITLE
docs: Add Maintainers and Community Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,22 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
+## Maintainers
+
+- **[@kolkov](https://github.com/kolkov)** - Creator & Lead Maintainer
+
+---
+
 ## Acknowledgments
 
+**Research:**
 - **Cormac Flanagan & Stephen Freund** - FastTrack algorithm (PLDI 2009)
 - **Dmitry Vyukov** - ThreadSanitizer and Go race detector integration
 - **Go Team** - Original race detector implementation
+
+**Community Contributors:**
+- **[@thepudds](https://github.com/thepudds)** - Critical bug report: pointer dereference instrumentation ([#27](https://github.com/kolkov/racedetector/issues/27))
+- **[@glycerine](https://github.com/glycerine)** - Extensive real-world testing on [zygomys](https://github.com/glycerine/zygomys) ([#15](https://github.com/kolkov/racedetector/issues/15), [#16](https://github.com/kolkov/racedetector/issues/16), [#17](https://github.com/kolkov/racedetector/issues/17))
 
 ---
 


### PR DESCRIPTION
## Summary

Add proper attribution for project maintainers and community contributors.

## Changes

- Add **Maintainers** section with @kolkov as Creator & Lead Maintainer
- Reorganize **Acknowledgments** into:
  - **Research** - Academic and technical foundations
  - **Community Contributors** - Bug reporters and testers

## Community Contributors Added

- **@thepudds** - Critical bug report: pointer dereference instrumentation (#27)
- **@glycerine** - Extensive real-world testing on zygomys (#15, #16, #17)

## Test plan

- [x] README renders correctly
- [x] All links valid